### PR TITLE
Fixed a minor typo in the cli

### DIFF
--- a/pkg/k8s/transport.go
+++ b/pkg/k8s/transport.go
@@ -110,5 +110,5 @@ func GetRunningPod(client *client.Client, ns, sts string) (string, string, error
 		return ns, randPort, nil
 	}
 
-	return "", "", fmt.Errorf("no running pods available in %s/%s. you can change the currnet context with 'kubemqctl config' command", ns, sts)
+	return "", "", fmt.Errorf("no running pods available in %s/%s. you can change the current context with 'kubemqctl config' command", ns, sts)
 }


### PR DESCRIPTION
Before:
```
Error: No Running Pods Available In Default/Kubemq-Cluster. You Can Change The Currnet Context With 'Kubemqctl Config' Command
```

After:
```
Error: No Running Pods Available In Default/Kubemq-Cluster. You Can Change The Current Context With 'Kubemqctl Config' Command
```